### PR TITLE
Add rust-toolchain.toml (stable channel); bump checkout to v7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build
         run: cargo build --release --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build & Test
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Create env file
       run: |
         touch .env

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -16,4 +16,4 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Create env file
         run: |
           touch .env

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+# Track the current stable Rust toolchain for local dev and CI.
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Adds rust-toolchain.toml on the stable channel and bumps actions/checkout v6->v7.